### PR TITLE
ServerBuilder::build(): Consider empty tokens to be invalid

### DIFF
--- a/src/ServerBuilder.cpp
+++ b/src/ServerBuilder.cpp
@@ -570,9 +570,6 @@ ServerConfig ServerBuilder::build(const std::vector<std::string>& directives) {
 
 	for (size_t line = 0; line < directives.size(); ++line) {
 		std::vector<std::string> tokens = splitParameters(directives[line]);
-		if (tokens.empty()) {
-			continue;
-		}
 		const std::string& directive = tokens[0];
 		HandlerFunc handler = getHandler(directive);
 		if (!handler) {


### PR DESCRIPTION
We should've removed empty tokens beforehand. Therefore, if such a token is found, treat is as invalid.

Currently present configs are readable and aren't borked by this change.